### PR TITLE
Made the theme switcher more accessible

### DIFF
--- a/src/components/ColorModeSwitcher.tsx
+++ b/src/components/ColorModeSwitcher.tsx
@@ -28,10 +28,26 @@ const ColorModeSwitcher: React.FC = () => {
     isInteractive: true,
   });
 
+  const previewStart = () => {
+    if (!isInteractive) return;
+
+    setState((state) => ({...state, isPreviewing: true, isInteractive: true}));
+  };
+
+  const previewEnd = () => {
+    setState((state) => ({...state, isPreviewing: false, isInteractive: true}));
+  };
+
   return (
     <>
-      <a
-        role="button"
+      <button
+        aria-checked={isToggled}
+        aria-label="dark theme"
+        className="p-2"
+        role="switch"
+        type="button"
+        value={isToggled ? "on" : "off"}
+        onBlur={previewEnd}
         onClick={() => {
           setState(({isToggled}) => ({
             isPreviewing: false,
@@ -39,14 +55,9 @@ const ColorModeSwitcher: React.FC = () => {
             isInteractive: false,
           }));
         }}
-        onMouseEnter={() => {
-          if (!isInteractive) return;
-
-          setState((state) => ({...state, isPreviewing: true, isInteractive: true}));
-        }}
-        onMouseLeave={() => {
-          setState((state) => ({...state, isPreviewing: false, isInteractive: true}));
-        }}
+        onFocus={previewStart}
+        onMouseEnter={previewStart}
+        onMouseLeave={previewEnd}
       >
         {isToggled ? (
           <svg height="16px" viewBox="0 0 24 24" width="16px">
@@ -76,7 +87,7 @@ const ColorModeSwitcher: React.FC = () => {
             </g>
           </svg>
         )}
-      </a>
+      </button>
       <Overlay isPreviewing={isPreviewing} isToggled={isToggled} />
     </>
   );


### PR DESCRIPTION
Accessibility is important, even for demos :smile: 

Keyboard fixes:
* Switched from `a` to `button`, as the a without an href wasn't keyboard focusable. This also allows you to switch themes back and forth using the space/enter keys.
* Added focus/blur previews and simplified into a `previewStart`/`previewEnd` functions.

Aria fixes:
* The `role` attribute should be `"switch"` to indicate the context of the action.
* Added `aria-label` to clarify what the button does (the screen reader will read the button as `dark theme switch on/off`).
* Added `aria-checked` to showcase the current state of the button.

Everything was based from https://www.radix-ui.com/docs/primitives/components/switch